### PR TITLE
Removed backslash in iio device path

### DIFF
--- a/RESOURCES/i2c-drivers/i2c-accel.sh
+++ b/RESOURCES/i2c-drivers/i2c-accel.sh
@@ -7,5 +7,5 @@ fi
 mkdir -p /sys/kernel/config/device-tree/overlays/accel
 dtc -W no-unit_address_vs_reg -@ -o /sys/kernel/config/device-tree/overlays/accel/dtbo i2c-accel.dts
 sleep 2
-cd "/sys/bus/iio/devices/iio\:device1"
+cd "/sys/bus/iio/devices/iio:device1"
 watch -n0 cat in_accel_x_raw in_accel_y_raw in_accel_z_raw 


### PR DESCRIPTION
The backslash was not necessary since : doesnt need to be escaped